### PR TITLE
Configurable Username Policies

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,14 +1,14 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"diet-ng": "1.1.1",
+		"diet-ng": "1.2.1",
 		"eventcore": "0.8.3",
-		"libasync": "0.7.9",
+		"libasync": "0.8.3",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "0.4.8",
+		"memutils": "0.4.9",
 		"openssl": "1.1.5+1.0.1g",
 		"taggedalgebraic": "0.10.5+commit.1.ge4c5ec7",
 		"vibe-core": "1.0.0-alpha.14+commit.1.gdae1ca7",
-		"vibe-d": "0.7.30"
+		"vibe-d": "0.7.31"
 	}
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,14 +1,14 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"diet-ng": "1.2.1",
+		"diet-ng": "1.1.1",
 		"eventcore": "0.8.3",
-		"libasync": "0.8.3",
+		"libasync": "0.7.9",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "0.4.9",
+		"memutils": "0.4.8",
 		"openssl": "1.1.5+1.0.1g",
 		"taggedalgebraic": "0.10.5+commit.1.ge4c5ec7",
 		"vibe-core": "1.0.0-alpha.14+commit.1.gdae1ca7",
-		"vibe-d": "0.7.31"
+		"vibe-d": "0.7.30"
 	}
 }

--- a/example/source/app.d
+++ b/example/source/app.d
@@ -9,7 +9,7 @@ import userman.web;
 shared static this()
 {
 	auto usettings = new UserManSettings;
-	usettings.requireAccountValidation = false;
+	usettings.requireActivation = false;
 	usettings.databaseURL = "file://./testdb/";
 
 	auto uctrl = createUserManController(usettings);

--- a/source/app.d
+++ b/source/app.d
@@ -41,7 +41,7 @@ shared static this()
 	}
 
 	auto usettings = new UserManSettings;
-	usettings.requireAccountValidation = false;
+	usettings.requireActivation = false;
 	usettings.databaseURL = "file://./testdb/";
 
 	auto uctrl = createUserManController(usettings);

--- a/source/userman/api.d
+++ b/source/userman/api.d
@@ -46,12 +46,11 @@ interface UserManAPI {
 	/// Interface suitable for manipulating group information
 	@property Collection!UserManGroupAPI groups();
 
-	@property APISettings settings();
+	@property UserManAPISettings settings();
 }
 
-struct APISettings {
-	UserManCommonSettings common;
-	alias common this;
+class UserManAPISettings : UserManCommonSettings {
+
 }
 
 /// Interface suitable for manipulating user information
@@ -231,7 +230,7 @@ private class UserManAPIImpl : UserManAPI {
 		UserManController m_ctrl;
 		UserManUserAPIImpl m_users;
 		UserManGroupAPIImpl m_groups;
-		APISettings m_settings;
+		UserManAPISettings m_settings;
 	}
 
 	this(UserManController ctrl)
@@ -249,7 +248,7 @@ private class UserManAPIImpl : UserManAPI {
 
 	@property Collection!UserManUserAPI users() { return Collection!UserManUserAPI(m_users); }
 	@property Collection!UserManGroupAPI groups() { return Collection!UserManGroupAPI(m_groups); }
-	@property APISettings settings() { return m_settings; }
+	@property UserManAPISettings settings() { return m_settings; }
 }
 
 private class UserManUserAPIImpl : UserManUserAPI {

--- a/source/userman/api.d
+++ b/source/userman/api.d
@@ -241,7 +241,7 @@ private class UserManAPIImpl : UserManAPI {
 		m_groups = new UserManGroupAPIImpl(ctrl);
 		m_settings.userNameSettings = ctrl.settings.userNameSettings;
 		m_settings.useUserNames = ctrl.settings.useUserNames;
-		m_settings.requireAccountValidation = ctrl.settings.requireAccountValidation;
+		m_settings.requireActivation = ctrl.settings.requireActivation;
 		m_settings.serviceName = ctrl.settings.serviceName;
 		m_settings.serviceURL = ctrl.settings.serviceURL;
 		m_settings.serviceEmail = ctrl.settings.serviceEmail;

--- a/source/userman/api.d
+++ b/source/userman/api.d
@@ -50,11 +50,8 @@ interface UserManAPI {
 }
 
 struct APISettings {
-	bool useUserNames;
-	bool requireActivation;
-	string serviceName;
-	URL serviceURL;
-	string serviceEmail;
+	UserManCommonSettings common;
+	alias common this;
 }
 
 /// Interface suitable for manipulating user information
@@ -242,10 +239,11 @@ private class UserManAPIImpl : UserManAPI {
 		m_ctrl = ctrl;
 		m_users = new UserManUserAPIImpl(ctrl);
 		m_groups = new UserManGroupAPIImpl(ctrl);
+		m_settings.userNameSettings = ctrl.settings.userNameSettings;
 		m_settings.useUserNames = ctrl.settings.useUserNames;
-		m_settings.requireActivation = ctrl.settings.requireAccountValidation;
+		m_settings.requireAccountValidation = ctrl.settings.requireAccountValidation;
 		m_settings.serviceName = ctrl.settings.serviceName;
-		m_settings.serviceURL = ctrl.settings.serviceUrl;
+		m_settings.serviceURL = ctrl.settings.serviceURL;
 		m_settings.serviceEmail = ctrl.settings.serviceEmail;
 	}
 

--- a/source/userman/db/controller.d
+++ b/source/userman/db/controller.d
@@ -71,7 +71,7 @@ class UserManController {
 		validateEmail(email);
 		validatePassword(password, password);
 
-		auto need_activation = m_settings.requireAccountValidation;
+		auto need_activation = m_settings.requireActivation;
 		User user;
 		user.active = !need_activation;
 		user.name = name;
@@ -109,8 +109,8 @@ class UserManController {
 			if( m_settings.mailSettings ){
 				auto msg = new MemoryOutputStream;
 				auto serviceName = m_settings.serviceName;
-				auto serviceUrl = m_settings.serviceUrl;
-				compileDietFile!("userman.mail.invitation.dt", user, serviceName, serviceUrl)(msg);
+				auto serviceURL = m_settings.serviceURL;
+				compileDietFile!("userman.mail.invitation.dt", user, serviceName, serviceURL)(msg);
 
 				auto mail = new Mail;
 				mail.headers["From"] = m_settings.serviceName ~ " <" ~ m_settings.serviceEmail ~ ">";
@@ -155,8 +155,8 @@ class UserManController {
 		
 		auto msg = new MemoryOutputStream;
 		auto serviceName = m_settings.serviceName;
-		auto serviceUrl = m_settings.serviceUrl;
-		compileDietFile!("userman.mail.activation.dt", user, serviceName, serviceUrl)(msg);
+		auto serviceURL = m_settings.serviceURL;
+		compileDietFile!("userman.mail.activation.dt", user, serviceName, serviceURL)(msg);
 
 		auto mail = new Mail;
 		mail.headers["From"] = m_settings.serviceName ~ " <" ~ m_settings.serviceEmail ~ ">";

--- a/source/userman/userman.d
+++ b/source/userman/userman.d
@@ -17,7 +17,7 @@ struct UserNameSettings {
 	int minLength = 3;
 	int maxLength = 32;
 	string additionalChars = "-_";
-	bool noNumberStart = false; // it's always a good idea to *not* able this option
+	bool noNumberStart = false; // it's always a good idea to keep this option *disabled* 
 }
 
 /**
@@ -26,11 +26,14 @@ struct UserNameSettings {
 struct UserManCommonSettings {
 	UserNameSettings userNameSettings;
 	bool useUserNames = true; // use a user name or the email address for identification?
-	bool requireAccountValidation;
-	deprecated("Consistency: Use .requireAccountValidation instead.") alias requireActivation = requireAccountValidation;
+	bool requireActivation;
 	string serviceName = "User database test";
 	URL serviceURL = "http://www.example.com/";
 	string serviceEmail = "userdb@example.com";
+
+	// The following line of code is responsible for the ocean of deprecation warnings.
+	// Removing it won't cause any harm to userman, but other software might depend on it.
+	deprecated("Consistency: Use .requireActivation instead.") alias requireAccountValidation = requireActivation;
 }
 
 class UserManSettings {
@@ -53,5 +56,4 @@ class UserManSettings {
 			this.common.serviceURL = value;
 		}
 	}
-	
 }

--- a/source/userman/userman.d
+++ b/source/userman/userman.d
@@ -23,7 +23,7 @@ class UserNameSettings {
 	string additionalChars = "-_";
 	bool noNumberStart = false; // it's always a good idea to keep this option *disabled* 
 
-	public bool validateUserName(R)(ref R error_sink, string userName)
+	package bool validateUserName(R)(ref R error_sink, string userName)
 		if (isOutputRange!(R, char))
 	{
 		return vibe.utils.validation.validateUserName(error_sink, userName,

--- a/source/userman/userman.d
+++ b/source/userman/userman.d
@@ -7,14 +7,17 @@
 */
 module userman.userman;
 
-import std.range : isOutputRange;
 public import vibe.mail.smtp;
 public import vibe.inet.url;
+
+static import vibe.utils.validation;
+
+import std.range : isOutputRange;
 
 /**
 	See_Also: vibe.utils.validation.validateUserName()
  */
-struct UserNameSettings {
+class UserNameSettings {
 	int minLength = 3;
 	int maxLength = 32;
 	string additionalChars = "-_";
@@ -34,7 +37,7 @@ struct UserNameSettings {
 /**
 	Settings also used by the API
  */
-struct UserManCommonSettings {
+class UserManCommonSettings {
 	UserNameSettings userNameSettings;
 	bool useUserNames = true; // use a user name or the email address for identification?
 	bool requireActivation;
@@ -42,29 +45,18 @@ struct UserManCommonSettings {
 	URL serviceURL = "http://www.example.com/";
 	string serviceEmail = "userdb@example.com";
 
-	// The following line of code is responsible for the ocean of deprecation warnings.
-	// Removing it won't cause any harm to userman, but other software might depend on it.
+	// The following lines of code are responsible for the ocean of deprecation warnings.
+	// Removing them won't cause any harm to userman, but other software might depend on them.
 	deprecated("Consistency: Use .requireActivation instead.") alias requireAccountValidation = requireActivation;
+	deprecated("Consistency: Use .serviceURL instead.") alias serviceUrl = serviceURL;
 }
 
-class UserManSettings {
-	UserManCommonSettings common;
-	alias common this;
-
+class UserManSettings : UserManCommonSettings {
 	string databaseURL = "mongodb://127.0.0.1:27017/test";//*/"redis://127.0.0.1:6379/1";
 	SMTPClientSettings mailSettings;
 
 	this()
 	{
 		mailSettings = new SMTPClientSettings;
-	}
-
-	deprecated("Consistency: Use .serviceURL instead.") @property {
-		URL serviceUrl() {
-			return this.common.serviceURL;
-		}
-		void serviceUrl(URL value) {
-			this.common.serviceURL = value;
-		}
 	}
 }

--- a/source/userman/userman.d
+++ b/source/userman/userman.d
@@ -7,6 +7,7 @@
 */
 module userman.userman;
 
+import std.range : isOutputRange;
 public import vibe.mail.smtp;
 public import vibe.inet.url;
 
@@ -18,6 +19,16 @@ struct UserNameSettings {
 	int maxLength = 32;
 	string additionalChars = "-_";
 	bool noNumberStart = false; // it's always a good idea to keep this option *disabled* 
+
+	public bool validateUserName(R)(ref R error_sink, string userName)
+		if (isOutputRange!(R, char))
+	{
+		return vibe.utils.validation.validateUserName(error_sink, userName,
+                this.minLength,
+                this.maxLength,
+                this.additionalChars,
+                this.noNumberStart);
+	}
 }
 
 /**

--- a/source/userman/userman.d
+++ b/source/userman/userman.d
@@ -10,17 +10,48 @@ module userman.userman;
 public import vibe.mail.smtp;
 public import vibe.inet.url;
 
-class UserManSettings {
-	bool requireAccountValidation = true;
+/**
+	See_Also: vibe.utils.validation.validateUserName()
+ */
+struct UserNameSettings {
+	int minLength = 3;
+	int maxLength = 32;
+	string additionalChars = "-_";
+	bool noNumberStart = false; // it's always a good idea to *not* able this option
+}
+
+/**
+	Settings also used by the API
+ */
+struct UserManCommonSettings {
+	UserNameSettings userNameSettings;
 	bool useUserNames = true; // use a user name or the email address for identification?
-	string databaseURL = "mongodb://127.0.0.1:27017/test";//*/"redis://127.0.0.1:6379/1";
+	bool requireAccountValidation;
+	deprecated("Consistency: Use .requireAccountValidation instead.") alias requireActivation = requireAccountValidation;
 	string serviceName = "User database test";
-	URL serviceUrl = "http://www.example.com/";
+	URL serviceURL = "http://www.example.com/";
 	string serviceEmail = "userdb@example.com";
+}
+
+class UserManSettings {
+	UserManCommonSettings common;
+	alias common this;
+
+	string databaseURL = "mongodb://127.0.0.1:27017/test";//*/"redis://127.0.0.1:6379/1";
 	SMTPClientSettings mailSettings;
 
 	this()
 	{
 		mailSettings = new SMTPClientSettings;
 	}
+
+	deprecated("Consistency: Use .serviceURL instead.") @property {
+		URL serviceUrl() {
+			return this.common.serviceURL;
+		}
+		void serviceUrl(URL value) {
+			this.common.serviceURL = value;
+		}
+	}
+	
 }

--- a/source/userman/web.d
+++ b/source/userman/web.d
@@ -326,7 +326,7 @@ class UserManWebInterface {
 	{
 		string username;
 		if (m_settings.useUserNames) {
-			enforce(name != null, "Missing user name field.");
+			enforce(!name.isNull, "Missing user name field.");
 
 			auto err = appender!string();
 			enforce(m_settings.userNameSettings.validateUserName(err, name), err.data);

--- a/source/userman/web.d
+++ b/source/userman/web.d
@@ -18,6 +18,7 @@ import vibe.utils.validation;
 import vibe.web.auth;
 import vibe.web.web;
 
+import std.array : appender;
 import std.exception;
 import std.typecons : Nullable;
 
@@ -259,7 +260,7 @@ class UserManWebInterface {
 		SessionVar!(string, "userName") m_sessUserName;
 		SessionVar!(string, "userFullName") m_sessUserFullName;
 		SessionVar!(string, "userID") m_sessUserID;
-		APISettings m_settings;
+		UserManAPISettings m_settings;
 	}
 	
 	this(UserManAPI api, string prefix = "/")

--- a/source/userman/web.d
+++ b/source/userman/web.d
@@ -322,7 +322,7 @@ class UserManWebInterface {
 	}
 	
 	@noAuth @errorDisplay!getRegister
-	void postRegister(ValidEmail email, string name, string fullName, ValidPassword password, Confirm!"password" passwordConfirmation)
+	void postRegister(ValidEmail email, Nullable!string name, string fullName, ValidPassword password, Confirm!"password" passwordConfirmation)
 	{
 		string username;
 		if (m_settings.useUserNames) {

--- a/source/userman/web.d
+++ b/source/userman/web.d
@@ -321,11 +321,19 @@ class UserManWebInterface {
 	}
 	
 	@noAuth @errorDisplay!getRegister
-	void postRegister(ValidEmail email, Nullable!ValidUsername name, string fullName, ValidPassword password, Confirm!"password" passwordConfirmation)
+	void postRegister(ValidEmail email, string name, string fullName, ValidPassword password, Confirm!"password" passwordConfirmation)
 	{
 		string username;
 		if (m_settings.useUserNames) {
-			enforce(!name.isNull(), "Missing user name field.");
+			enforce(name != null, "Missing user name field.");
+
+			auto err = appender!string();
+			enforce(validateUserName(err, name,
+                m_settings.userNameSettings.minLength,
+                m_settings.userNameSettings.maxLength,
+                m_settings.userNameSettings.additionalChars,
+                m_settings.userNameSettings.noNumberStart), err.data);
+
 			username = name;
 		} else username = email;
 

--- a/source/userman/web.d
+++ b/source/userman/web.d
@@ -328,11 +328,7 @@ class UserManWebInterface {
 			enforce(name != null, "Missing user name field.");
 
 			auto err = appender!string();
-			enforce(validateUserName(err, name,
-                m_settings.userNameSettings.minLength,
-                m_settings.userNameSettings.maxLength,
-                m_settings.userNameSettings.additionalChars,
-                m_settings.userNameSettings.noNumberStart), err.data);
+			enforce(m_settings.userNameSettings.validateUserName(err, name), err.data);
 
 			username = name;
 		} else username = email;

--- a/source/userman/webadmin.d
+++ b/source/userman/webadmin.d
@@ -18,6 +18,7 @@ import vibe.web.auth;
 import vibe.web.web;
 
 import std.algorithm : min, max;
+import std.array : appender;
 import std.conv : to;
 import std.exception;
 import std.typecons : Nullable;
@@ -319,7 +320,7 @@ class UserManWebAdminInterface {
 	{
 		struct Info {
 			string error;
-			APISettings settings;
+			UserManAPISettings settings;
 		}
 
 		Info info;

--- a/source/userman/webadmin.d
+++ b/source/userman/webadmin.d
@@ -80,8 +80,11 @@ class UserManWebAdminInterface {
 	}
 
 	@noAuth @errorDisplay!getLogin
-	void postInitialRegister(ValidUsername username, ValidEmail email, string full_name, ValidPassword password, Confirm!"password" password_confirmation, string redirect = "/")
+	void postInitialRegister(string username, ValidEmail email, string full_name, ValidPassword password, Confirm!"password" password_confirmation, string redirect = "/")
 	{
+		auto err = appender!string();
+		enforceHTTP(m_api.settings.userNameSettings.validateUserName(err, username), HTTPStatus.badRequest, err.data);
+
 		enforceHTTP(m_api.users.count == 0, HTTPStatus.forbidden, "Cannot create initial admin account when other accounts already exist.");
 		try m_api.groups[adminGroupName].get();
 		catch (Exception) m_api.groups.create(adminGroupName, "UserMan Administrators");
@@ -129,8 +132,11 @@ class UserManWebAdminInterface {
 	}
 
 	@errorDisplay!getUsers
-	void postUsers(AuthInfo auth, ValidUsername name, ValidEmail email, string full_name, ValidPassword password, Confirm!"password" password_confirmation)
+	void postUsers(AuthInfo auth, string name, ValidEmail email, string full_name, ValidPassword password, Confirm!"password" password_confirmation)
 	{
+		auto err = appender!string();
+		enforceHTTP(m_api.settings.userNameSettings.validateUserName(err, name), HTTPStatus.badRequest, err.data);
+
 		m_api.users.register(email, name, full_name, password);
 		redirect("users");
 	}
@@ -162,8 +168,11 @@ class UserManWebAdminInterface {
 	}
 
 	@path("/users/:user/") @errorDisplay!getUser
-	void postUser(AuthInfo auth, User.ID _user, ValidUsername username, ValidEmail email, string full_name, bool active, bool banned)
+	void postUser(AuthInfo auth, User.ID _user, string username, ValidEmail email, string full_name, bool active, bool banned)
 	{
+		auto err = appender!string();
+		enforceHTTP(m_api.settings.userNameSettings.validateUserName(err, username), HTTPStatus.badRequest, err.data);
+
 		//m_api.users[_user].setName(username); // TODO!
 		m_api.users[_user].setEmail(email);
 		m_api.users[_user].setFullName(full_name);

--- a/views/userman.admin.settings.dt
+++ b/views/userman.admin.settings.dt
@@ -21,7 +21,27 @@ block userman.content
 			tr
 				th
 					input#useUserNames(type="checkbox", name="settings.useUserNames", checked=info.settings.useUserNames)
-					label(for="useUserNames")& Use user names
+					label(for="useUserNames")& Use usernames
+				td &nbsp;
+			tr
+				th
+					label(for="minLength")& A username's minimum length
+				td
+					input#minLength(type="number", name="settings.userNameSettings.minLength", value=info.settings.userNameSettings.minLength)
+			tr
+				th
+					label(for="maxLength")& A username's maximum length
+				td
+					input#maxLength(type="number", name="settings.userNameSettings.maxLength", value=info.settings.userNameSettings.maxLength)
+			tr
+				th
+					label(for="additionalChars")& Additional chars allowed in usernames
+				td
+					input#additionalChars(type="text", name="settings.userNameSettings.additionalChars", value=info.settings.userNameSettings.additionalChars)
+			tr
+				th
+					input#noNumberStart(type="checkbox", name="settings.userNameSettings.noNumberStart", checked=info.settings.userNameSettings.noNumberStart)
+					label(for="noNumberStart")& Usernames mustn't start with a number [Dangerous]
 				td &nbsp;
 			tr
 				th

--- a/views/userman.admin.settings.dt
+++ b/views/userman.admin.settings.dt
@@ -41,7 +41,7 @@ block userman.content
 			tr
 				th
 					input#noNumberStart(type="checkbox", name="settings.userNameSettings.noNumberStart", checked=info.settings.userNameSettings.noNumberStart)
-					label(for="noNumberStart")& Usernames mustn't start with a number [Dangerous]
+					label(for="noNumberStart")& Usernames mustn't start with a number [Not recommended!]
 				td &nbsp;
 			tr
 				th

--- a/views/userman.mail.activation.dt
+++ b/views/userman.mail.activation.dt
@@ -14,7 +14,7 @@ block body
 	p If you did not make this request, you can safely ignore this message.
 	p Otherwise, please open the link below in your browser to confirm the activation:
 	p
-		- auto link = serviceUrl;
+		- auto link = serviceURL;
 		- link.path = Path("/activate");
 		- link.queryString = "email="~urlEncode(user.email)~"&code="~urlEncode(user.activationCode);
 		a(href="#{link}")= link

--- a/views/userman.mail.invitation.dt
+++ b/views/userman.mail.invitation.dt
@@ -10,7 +10,7 @@ block body
 	h1 Invitation to #{serviceName}
 	
 	p Dear #{user.fullName},
-	- auto link = serviceUrl;
+	- auto link = serviceURL;
 	- link.path = Path("/register");
 	- link.queryString = "email="~urlEncode(user.email);
 	p You have been invited to #{serviceName}. To accept the invitation, please go to <a href="#{link}">#{link}</a> and register an account.

--- a/views/userman.mail.reset_password.dt
+++ b/views/userman.mail.reset_password.dt
@@ -9,7 +9,7 @@ block body
 	p A request has been made to set a new password for your #{settings.serviceName} account. If you made this request, just follow the link below to be able to choose a new password. The link is valid for 24 hours and will only work once. After that you will have to make a new request.
 
 	p
-		- auto link = settings.serviceUrl;
+		- auto link = settings.serviceURL;
 		- link.path = Path("/reset_password");
 		- link.queryString = "email="~urlEncode(user.email)~"&code="~urlEncode(reset_code);
 		a(href="#{link}") #{link}


### PR DESCRIPTION
My changes add the possibility to configure what username policies are applied.


## The main reason

The year is 2017. Homosexual people in the Netherlands have been allowed to marry for over 16 years by now; more and more countries have been or are following. Almost all European countries have abandoned the death penalty.

Nevertheless, people wanting to register with usernames that start with a number (like mine does 😊) **cannot signup** on several pages. This includes practically all services relying on _userman_ (and thus also the dub-registry).

It's a shame that people still have to use umpteen fancy usernames on different sites because of weird and incomprehensible policies all over the WWW.

I wonder if this is really necessary ...
Why can't I simply have one single username that I can use everywhere? Because it's a hex number? Because it starts with a number? Because it has only 5 characters? Because it's easy to remember as it's based on my name's initials?
Whatever it is, it's always just ridiculous. Well, I'm a bit disappointed.

## Findings
As you might guess, _userman_'s new default setting for `noNumberStart` is, of course, `false`. Because it would be simply wrong to enable it. If someone really needs to enforce this (and I doubt there will ever be one), she/he can enable it explicitly on purpose.

## By the way
Facebook, Twitter, VK, GitHub, GitLab, Discord, and so on, all those allow usernames starting with a number.

## Note
I don't want to accuse anyone of anything. In this case, the problem simply comes from a design flaw in the defaults of _vibe.d_'s username validation and _userman_ was only affected because it lazily relied on those.

## Conclusion
**I would be very happy if these changes would find their way into the dub-registry one day.**