### PR TITLE
Upgrade dependencies to build against latest compiler

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ authors "Sönke Ludwig"
 copyright "Copyright (c) 2012-2020 rejectedsoftware e.K."
 license "GPL-3.0"
 
-dependency "vibe-d" version=">=0.8.2 <0.10.0-0"
+dependency "vibe-d" version=">=0.9.7 <0.11.0"
 
 configuration "application" {
 	targetType "executable"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -4,16 +4,22 @@
 		"botan": "1.12.18",
 		"botan-math": "1.0.3",
 		"diet-ng": "1.8.1",
-		"eventcore": "0.9.23",
+		"eventcore": "0.9.30",
 		"libasync": "0.8.6",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "1.0.9",
+		"memutils": "1.0.10",
 		"mir-linux-kernel": "1.0.1",
-		"openssl": "3.3.0",
+		"openssl": "3.3.3",
+		"openssl-static": "1.0.5+3.0.8",
 		"silly": "1.1.1",
 		"stdx-allocator": "2.77.5",
-		"taggedalgebraic": "0.11.22",
-		"vibe-core": "1.24.0",
-		"vibe-d": "0.9.5"
+		"taggedalgebraic": "0.11.23",
+		"vibe-container": "1.3.1",
+		"vibe-core": "2.8.4",
+		"vibe-d": "0.10.0",
+		"vibe-http": "1.1.0",
+		"vibe-inet": "1.0.0",
+		"vibe-serialization": "1.0.3",
+		"vibe-stream": "1.1.0"
 	}
 }


### PR DESCRIPTION
Trying to 'dub test' with vibe-d v0.9.5 leads to a safe-related error.

@s-ludwig : Could you review ? This is needed for me to be able to work on `dub-registry`.