### PR TITLE
Trivial: Simplify md5hash by removing support for DMD < v2.061

### DIFF
--- a/source/userman/db/controller.d
+++ b/source/userman/db/controller.d
@@ -353,23 +353,13 @@ unittest {
 	assert(validatePasswordHash(h, "foobar"));
 }
 
-private ubyte[16] md5hash(ubyte[] salt, string[] strs...)
+private ubyte[16] md5hash(scope const(ubyte)[] salt, const string[] strs...)
 @safe {
-	static if( __traits(compiles, {import std.digest.md;}) ){
-		import std.digest.md;
-		MD5 ctx;
-		ctx.start();
-		ctx.put(salt);
-		foreach( s; strs ) ctx.put(cast(const(ubyte)[])s);
-		return ctx.finish();
-	} else {
-		import std.md5;
-		ubyte[16] hash;
-		MD5_CTX ctx;
-		ctx.start();
-		ctx.update(salt);
-		foreach( s; strs ) ctx.update(s);
-		ctx.finish(hash);
-		return hash;
-	}
+	import std.digest.md;
+
+	MD5 ctx;
+	ctx.start();
+	ctx.put(salt);
+	foreach (s; strs) ctx.put(cast(const(ubyte)[])s);
+	return ctx.finish();
 }


### PR DESCRIPTION
This static if branch has been used for the last 11 years, so it time to simplify it. Also slightly change the prototype in the process to get rid of a safe/scope deprecation.

https://github.com/dlang/phobos/commit/6ff6adc5bf7d13b33e27985c53377cd20d7648e6